### PR TITLE
Added command line arguments for GCP settings

### DIFF
--- a/custom-metrics-stackdriver-adapter/Dockerfile
+++ b/custom-metrics-stackdriver-adapter/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.22-alpine as builder
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-stackdriver/custom-metrics-stackdriver-adapter
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o /adapter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=readonly -o /adapter
 RUN ! ldd cluster-addons-bootstrap # Assert that the compiled bin is statically linked
 
 FROM gcr.io/distroless/static

--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -249,6 +249,12 @@ func main() {
 	} else {
 		klog.Infof("ListFullCustomMetrics is disabled, which would only list 1 metric resource to reduce memory usage. Add --list-full-custom-metrics to list full metric resources for debugging.")
 	}
+	if (serverOptions.Cluster == "") != (serverOptions.ProjectId == "") {
+		klog.Fatalf("'cluster' should be set if and only if 'project-id' is set.")
+	}
+	if (serverOptions.Location == "") != (serverOptions.ProjectId == "") {
+		klog.Fatalf("'location' should be set if and only if 'project-id' is set.")
+	}
 
 	// TODO(holubwicz): move duration config to server options
 	metricsProvider, translator := cmd.makeProviderOrDie(&serverOptions, 5*time.Minute, 1*time.Minute)
@@ -268,13 +274,6 @@ func main() {
 	}
 	if err := cmd.Run(wait.NeverStop); err != nil {
 		klog.Fatalf("unable to run custom metrics adapter: %v", err)
-	}
-
-	if (serverOptions.Cluster == "") != (serverOptions.ProjectId == "") {
-		klog.Fatalf("'cluster' should be set if and only if 'project-id' is set.")
-	}
-	if (serverOptions.Location == "") != (serverOptions.ProjectId == "") {
-		klog.Fatalf("'location' should be set if and only if 'project-id' is set.")
 	}
 }
 

--- a/custom-metrics-stackdriver-adapter/adapter.go
+++ b/custom-metrics-stackdriver-adapter/adapter.go
@@ -230,7 +230,7 @@ func main() {
 		"enables support for scaling based on distribution values")
 	// Custom flags
 	flags.StringVar(&serverOptions.ProjectId, "project-id", "",
-		"Project ID of the Google Cloud cluster. May be left empty on GKE.")
+		"Project ID on Google Cloud. May be left empty on GKE.")
 	flags.StringVar(&serverOptions.Cluster, "cluster", "",
 		"Name of the cluster the adapter acts on. May be left empty on GKE.")
 	flags.StringVar(&serverOptions.Location, "location", "",


### PR DESCRIPTION
Allows passing command line parameters from helm as follows:

command:

/adapter
--project-id={{ .Values.projectId }}
--location={{ .Values.location }}
--cluster={{ .Values.cluster }}